### PR TITLE
Projects can now have independent roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ $ ./key-gen.sh
 `config.yml` is the config file. The sample configuration file will work without any modifications, and is created by the `setup` command. By default, it should look like this:
 
 ```yaml
-address: localhost
-port: 3000
-root: site
-projects: projects
+address:  localhost
+port:     3000
+root:     site
+projects: site/projects
 user-key: ./user/login.key
 database: ./user/projects.yml
 ```

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -1,6 +1,6 @@
-address: localhost
-port: 3000
-root: site
-projects: projects
+address:  localhost
+port:     3000
+root:     site
+projects: site/projects
 user-key: ./user/login.key
 database: ./user/projects.yml

--- a/lib/backend.rb
+++ b/lib/backend.rb
@@ -62,7 +62,7 @@ class Backend
 
 			# Update repo
 			when "/update"
-				attempt_script_and_redirect "./lib/scripting/update.rb #{data["project"]} #{data["user"]} #{data["repo"]} #{data["desc"]} #{data["old"]}", "/dash"
+				attempt_script_and_redirect "./lib/scripting/update.rb #{data["project"]} #{data["user"]} #{data["repo"]} #{data["desc"]} #{data["root"]} #{data["old"]}", "/dash"
 
 			# Else it's probably a 404
 			else

--- a/lib/frontend.rb
+++ b/lib/frontend.rb
@@ -14,16 +14,18 @@ class Frontend
 			request[1] = '/index.html'
 		end
 
+		# Route to directory
+		if request[1] == "/dir"
+			request[1] = "/directory.html"
+			data = read_YAML(read_YAML("config.yml")["database"])
+		end
+
+		# Projects have special routing rules
 		if request[1][0..2] == "/p/"
 			request[1].gsub!("/p/", "/projects/")
 			if request[-1] == "/"
 				k += "index.html"
 			end
-		end
-
-		if request[1] == "/dir"
-			request[1] = "/directory.html"
-			data = read_YAML(read_YAML("config.yml")["database"])
 		end
 
 		@socket.print http_compose request[1], data

--- a/lib/frontend.rb
+++ b/lib/frontend.rb
@@ -42,8 +42,6 @@ class Frontend
 			if request[-1] == "/"
 				url += "index.html"
 			end
-
-			print url
 		end
 
 

--- a/lib/scripting/new-project.rb
+++ b/lib/scripting/new-project.rb
@@ -37,5 +37,6 @@ File.open("projects.yml", 'a') do |file|
 	file.puts "  project: #{repo}\n"
 	file.puts "  user: #{user}\n"
 	file.puts "  desc: (none yet!)"
+	file.puts "  root: /"
 	file.puts ""
 end

--- a/lib/scripting/new-project.rb
+++ b/lib/scripting/new-project.rb
@@ -7,7 +7,7 @@ user = ARGV[0]
 repo = ARGV[1]
 
 # Clone repo into projects
-Dir.chdir("#{@config['root']}/#{@config['projects']}")
+Dir.chdir("#{@config['projects']}")
 puts `git clone --depth=1 https://github.com/#{user}/#{repo}.git`
 
 # Set it up

--- a/lib/scripting/new-project.rb
+++ b/lib/scripting/new-project.rb
@@ -37,6 +37,6 @@ File.open("projects.yml", 'a') do |file|
 	file.puts "  project: #{repo}\n"
 	file.puts "  user: #{user}\n"
 	file.puts "  desc: (none yet!)"
-	file.puts "  root: /"
+	file.puts "  root: ''"
 	file.puts ""
 end

--- a/lib/scripting/pull.rb
+++ b/lib/scripting/pull.rb
@@ -5,7 +5,7 @@ require_relative '../utility.rb'
 
 project = ARGV[0]
 
-Dir.chdir("#{@config['root']}/#{@config['projects']}/#{project}")
+Dir.chdir("#{@config['projects']}/#{project}")
 
 # puts `git remote show origin`
 puts `git fetch origin && git reset --hard origin/master && ./setup`

--- a/lib/scripting/remove.rb
+++ b/lib/scripting/remove.rb
@@ -9,7 +9,7 @@ projects = read_YAML(@config["database"])
 
 write_YAML @config["database"], projects.select { |e| e["project"] != project }
 
-Dir.chdir("#{@config['root']}/#{@config['projects']}")
+Dir.chdir("#{@config['projects']}")
 
 puts `rm -rf #{project}`
 

--- a/lib/scripting/update.rb
+++ b/lib/scripting/update.rb
@@ -17,5 +17,5 @@ projects = projects.select { |e| e["project"] != old }
 projects.push({'repo' => repo, 'project' => project, 'user' => user, 'desc' => desc, 'root' => root})
 write_YAML @config["database"], projects
 
-Dir.chdir("#{@config['root']}/#{@config['projects']}")
+Dir.chdir("#{@config['projects']}")
 puts `mv #{old} #{project}`

--- a/lib/scripting/update.rb
+++ b/lib/scripting/update.rb
@@ -9,11 +9,12 @@ project  = CGI::unescape ARGV[0]
 user 	 = ARGV[1]
 repo 	 = ARGV[2]
 desc 	 = CGI::unescape ARGV[3]
-old 	 = CGI::unescape ARGV[4]
+root 	 = ARGV[4]
+old 	 = CGI::unescape ARGV[5]
 
 projects = read_YAML(@config["database"])
 projects = projects.select { |e| e["project"] != old }
-projects.push({'repo' => repo, 'project' => project, 'user' => user, 'desc' => desc})
+projects.push({'repo' => repo, 'project' => project, 'user' => user, 'desc' => desc, 'root' => root})
 write_YAML @config["database"], projects
 
 Dir.chdir("#{@config['root']}/#{@config['projects']}")

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -91,6 +91,9 @@
 										<label class="label">Description: </label>
 										<input name="desc" class="input" type="text" value="{{{ desc }}}">
 
+										<label class="label">Project Root: </label>
+										<input name="root" class="input" type="text" value="{{{ root }}}">
+
 										<label class="label">Save Changes:</label>
 										<p class="control has-addons">
 											<input class="input" type="password" name="password" placeholder="Password..." required>


### PR DESCRIPTION
Current sites will continue working, but allow for a site-specific root. This means that jekyll sites can be served from _site with no change from the visiting user